### PR TITLE
Implement reoptimize for IntegrationProfiler

### DIFF
--- a/src/odeprob_utils.jl
+++ b/src/odeprob_utils.jl
@@ -49,8 +49,8 @@ function solver_init(sciml_prob::SciMLBase.AbstractODEProblem,
   # optimizer state, and register a callback.
   callback = nothing
   if method.reoptimize
-    sciml_prob_opt = build_optprob_reduced(deepcopy(plprob.optprob), deepcopy(plprob.optpars))
-    solver_state_opt = solver_init(sciml_prob_opt, deepcopy(plprob), method, idx, dir, profile_bound)
+    sciml_prob_opt = build_optprob_reduced(plprob.optprob, plprob.optpars)
+    solver_state_opt = solver_init(sciml_prob_opt, plprob, method, idx, dir, profile_bound)
     condition(u, t, integrator) = true
     function affect!(integrator)
       set_x_fixed!(solver_state_opt.reinit_cache.p, integrator.u[idx])

--- a/src/optprob_utils.jl
+++ b/src/optprob_utils.jl
@@ -31,8 +31,9 @@ function solver_reinit!(solver_state::OptimizationBase.OptimizationCache, plprob
 end
 =#
 
+# Accept both OptimizationProfiler and IntegrationProfiler with reoptimize=true
 function solver_init(sciml_prob::SciMLBase.OptimizationProblem, 
-  plprob::PLProblem, method::OptimizationProfiler, idx, dir, profile_bound)
+  plprob::PLProblem, method::AbstractProfilerMethod, idx, dir, profile_bound)
   
   optprob = get_optprob(plprob)
   u0_full = get_optpars(plprob)

--- a/src/profile_methods.jl
+++ b/src/profile_methods.jl
@@ -68,6 +68,8 @@ get_integrator(ip::IntegrationProfiler) = ip.integrator
 get_integrator_opts(ip::IntegrationProfiler) = ip.integrator_opts
 get_matrix_type(ip::IntegrationProfiler) = ip.matrix_type
 get_gamma(ip::IntegrationProfiler) = ip.gamma
+get_optimizer(ip::IntegrationProfiler) = ip.optimizer
+get_optimizer_opts(ip::IntegrationProfiler) = ip.optimizer_opts
 
 ############################## CICOProfiler ##############################
 

--- a/test/test_analytic_funcs.jl
+++ b/test/test_analytic_funcs.jl
@@ -67,6 +67,20 @@ end
   
 end
 
+@testset "Analytic funcs. IntegrationProfiler with identity matrix + reoptimize" begin
+
+  method = IntegrationProfiler(
+    integrator = Rosenbrock23(autodiff=false),
+    integrator_opts = (dtmax=0.3,),
+    matrix_type = :identity,
+    gamma=0.2,            # (!!!) select "bad" gamma
+    reoptimize=true,
+    optimizer = Optimization.LBFGS()
+  )
+  test_plmethod(method, funcs_dict)
+
+end
+
 # @testset "Analytic funcs. IntegrationProfiler with Fisher matrix" begin
 
 #   method = IntegrationProfiler(


### PR DESCRIPTION
Usage example with the identity matrix with gamma=0.2:

```julia
using LikelihoodProfiler
using Optimization, ForwardDiff, OrdinaryDiffEq, OrdinaryDiffEqCore, OrdinaryDiffEqTsit5
using Plots

# objective function
rosenbrock(x,p) = (1.0 - x[1])^2 + 100.0*(x[2] - x[1]^2)^2

# Initial values
x0 = zeros(2)

# Solving optimization problem
optf = OptimizationFunction(rosenbrock, AutoForwardDiff())
optprob = OptimizationProblem(optf, x0)
sol = solve(optprob, Optimization.LBFGS())

sol_u = sol.u

plprob = PLProblem(optprob, sol_u, (-5.,5.); threshold = 1.0)

method = IntegrationProfiler(
    integrator = Rosenbrock23(autodiff=false), 
    integrator_opts = (dtmax=0.3,), 
    matrix_type = :identity,
    gamma=0.2,
    reoptimize=true,
    optimizer = Optimization.LBFGS()
)
sol = profile(plprob, method)
plot(sol, size=(800,300))
```