### PR TITLE
Support symbolic parameter labels/indexing, expose profile symbols, and fix constrained optf kwargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ repo-url = "https://github.com/insysbio/LikelihoodProfiler.jl"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -24,9 +23,11 @@ SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [weakdeps]
 CICOBase = "33444335-3134-4342-4659-594331344435"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 
 [extensions]
 CICOBaseExt = "CICOBase"
+ComponentArraysExt = "ComponentArrays"
 
 [compat]
 ADTypes = "1.21.0"
@@ -49,6 +50,7 @@ julia = "1.10"
 
 [extras]
 CICOBase = "33444335-3134-4342-4659-594331344435"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 OptimizationLBFGSB = "22f7324a-a79d-40f2-bebe-3af60c77bd15"
 OptimizationNLopt = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
@@ -57,4 +59,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CICOBase", "Plots", "ForwardDiff", "OptimizationLBFGSB", "OptimizationNLopt", "OrdinaryDiffEq"]
+test = ["Test", "CICOBase", "ComponentArrays", "Plots", "ForwardDiff", "OptimizationLBFGSB", "OptimizationNLopt", "OrdinaryDiffEq"]

--- a/ext/ComponentArraysExt.jl
+++ b/ext/ComponentArraysExt.jl
@@ -2,9 +2,9 @@ module ComponentArraysExt
 
 using LikelihoodProfiler, ComponentArrays
 
-function LikelihoodProfiler._infer_parameter_labels(optpars::ComponentArrays.ComponentArray)
-  ks = collect(keys(optpars))
-  n = length(optpars)
+function LikelihoodProfiler._infer_container_labels(::Type{<:ComponentArrays.ComponentArray}, x)
+  ks = collect(keys(x))
+  n = length(x)
   if length(ks) == n && all(k -> (k isa Symbol || k isa AbstractString), ks)
     inferred_labels = [k isa Symbol ? k : Symbol(k) for k in ks]
     allunique(inferred_labels) || return nothing

--- a/ext/ComponentArraysExt.jl
+++ b/ext/ComponentArraysExt.jl
@@ -1,0 +1,16 @@
+module ComponentArraysExt
+
+using LikelihoodProfiler, ComponentArrays
+
+function LikelihoodProfiler._infer_parameter_labels(optpars::ComponentArrays.ComponentArray)
+  ks = collect(keys(optpars))
+  n = length(optpars)
+  if length(ks) == n && all(k -> (k isa Symbol || k isa AbstractString), ks)
+    inferred_labels = [k isa Symbol ? k : Symbol(k) for k in ks]
+    allunique(inferred_labels) || return nothing
+    return inferred_labels
+  end
+  return nothing
+end
+
+end #module

--- a/src/LikelihoodProfiler.jl
+++ b/src/LikelihoodProfiler.jl
@@ -39,5 +39,7 @@ export FixedStep # LineSearchStep, InterpolationLineSearch
 export chi2_quantile
 export OptimizationProfiler, IntegrationProfiler, CICOProfiler
 export endpoints, stats, retcodes, obj_level
+export parameter_syms, profile_syms
+export profile_labels
 
 end #module LikelihoodProfiler

--- a/src/LikelihoodProfiler.jl
+++ b/src/LikelihoodProfiler.jl
@@ -1,7 +1,6 @@
 module LikelihoodProfiler
 
 using PreallocationTools
-using ComponentArrays
 using SimpleUnPack: @unpack
 using Reexport
 using Optimization
@@ -39,7 +38,6 @@ export FixedStep # LineSearchStep, InterpolationLineSearch
 export chi2_quantile
 export OptimizationProfiler, IntegrationProfiler, CICOProfiler
 export endpoints, stats, retcodes, obj_level
-export parameter_syms, profile_syms
-export profile_labels
+export labels
 
 end #module LikelihoodProfiler

--- a/src/LikelihoodProfiler.jl
+++ b/src/LikelihoodProfiler.jl
@@ -38,6 +38,6 @@ export FixedStep # LineSearchStep, InterpolationLineSearch
 export chi2_quantile
 export OptimizationProfiler, IntegrationProfiler, CICOProfiler
 export endpoints, stats, retcodes, obj_level
-export labels
+export profile_labels
 
 end #module LikelihoodProfiler

--- a/src/optprob_utils.jl
+++ b/src/optprob_utils.jl
@@ -116,5 +116,11 @@ function build_optf_constrained(plprob::ProfileLikelihoodProblem, idx)
     res[1] = cons_optf.f(x, p)
     return nothing
   end
-  return OptimizationFunction(optprob.f.f, cons_optf.adtype; grad=optprob.f.grad, hess=optprob.f.hess, cons = cons_f)
+  kwargs = Dict{Symbol,Any}()
+  for p in propertynames(optprob.f)
+    if p ∉ (:f, :adtype, :grad, :hess, :cons)
+      kwargs[p] = getfield(optprob.f, p)
+    end
+  end
+  return OptimizationFunction(optprob.f.f, cons_optf.adtype; grad=optprob.f.grad, hess=optprob.f.hess, cons = cons_f, kwargs...)
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,11 +1,11 @@
 
 @recipe function f(sol::ProfileLikelihoodSolution)
   ls = length(sol)
-  syms = profile_syms(sol.prob)
+  lbls = labels(sol)
 
   layout --> ls
   for i in 1:ls
-    xlbl = isnothing(syms) ? "x[$(i)]" : string(syms[i])
+    xlbl = isnothing(lbls) ? "x[$(i)]" : string(lbls[i])
     @series begin
       subplot := i
       xguide --> xlbl

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,12 +1,14 @@
 
 @recipe function f(sol::ProfileLikelihoodSolution)
   ls = length(sol)
+  syms = profile_syms(sol.prob)
 
   layout --> ls
   for i in 1:ls
+    xlbl = isnothing(syms) ? "x[$(i)]" : string(syms[i])
     @series begin
       subplot := i
-      xguide --> "x[$(i)]"
+      xguide --> xlbl
       yguide --> "objective function"
       sol[i]
     end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,7 +1,7 @@
 
 @recipe function f(sol::ProfileLikelihoodSolution)
   ls = length(sol)
-  lbls = labels(sol)
+  lbls = profile_labels(sol)
 
   layout --> ls
   for i in 1:ls

--- a/src/problem_interface.jl
+++ b/src/problem_interface.jl
@@ -221,7 +221,7 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
   (isnothing(lb) || isnothing(ub)) &&
      throw(ArgumentError("Bounds not found in `OptimizationProblem`; pass `profile_lower`/`profile_upper`."))
 
-  I = _materialize_idxs(idxs, n; syms=param_labels)
+  I = _materialize_idxs(idxs, n; labels=param_labels)
   lbv = _materialize_profile_bound(lb, length(I))
   ubv = _materialize_profile_bound(ub, length(I))
 
@@ -270,7 +270,7 @@ function _check_prob_target(optprob::OptimizationProblem, optpars::AbstractVecto
   return nothing
 end
 
-function _materialize_idxs(idxs, n::Int; syms=nothing)
+function _materialize_idxs(idxs, n::Int; labels=nothing)
   if isnothing(idxs)
     return collect(Base.OneTo(n))
   elseif idxs isa Integer && 1 <= idxs <= n
@@ -278,11 +278,11 @@ function _materialize_idxs(idxs, n::Int; syms=nothing)
   elseif idxs isa AbstractVector{<:Integer} && all(1 .<= idxs .<= n)
     return Int.(collect(idxs))
   elseif idxs isa Symbol
-    return [_symbol_to_idx(idxs, syms, n)]
+    return [_symbol_to_idx(idxs, labels, n)]
   elseif idxs isa AbstractVector{<:Symbol}
-    return [_symbol_to_idx(s, syms, n) for s in idxs]
+    return [_symbol_to_idx(s, labels, n) for s in idxs]
   elseif idxs isa AbstractVector && all(x -> (x isa Integer || x isa Symbol), idxs)
-    I = [x isa Integer ? Int(x) : _symbol_to_idx(x, syms, n) for x in idxs]
+    I = [x isa Integer ? Int(x) : _symbol_to_idx(x, labels, n) for x in idxs]
     all(1 .<= I .<= n) || throw(ArgumentError("`idxs` must be within 1:$n."))
     return I
   else
@@ -290,25 +290,15 @@ function _materialize_idxs(idxs, n::Int; syms=nothing)
   end
 end
 
-function _symbol_to_idx(s::Symbol, syms, n::Int)
-  isnothing(syms) &&
-    throw(ArgumentError("Symbolic `idxs` requested but parameter symbols were not detected. Pass named `ComponentArray` as `optpars` (e.g. `ComponentArray(a=..., b=...)`) or use integer indices."))
-  idx = findfirst(==(s), syms)
-  isnothing(idx) && throw(ArgumentError("Symbol `$s` is not present in parameter symbols $syms."))
+function _symbol_to_idx(s::Symbol, labels, n::Int)
+  isnothing(labels) &&
+    throw(ArgumentError("Symbolic `idxs` requested but parameter labels were not detected. Pass named parameter labels through `labels` or use integer indices."))
+  idx = findfirst(==(s), labels)
+  isnothing(idx) && throw(ArgumentError("Symbol `$s` is not present in parameter labels $labels."))
   return idx
 end
 
 function _infer_parameter_labels(optpars::AbstractVector)
-  n = length(optpars)
-  if optpars isa ComponentArrays.ComponentArray
-    ks = collect(keys(optpars))
-    if length(ks) == n && all(k -> (k isa Symbol || k isa AbstractString), ks)
-      inferred_syms = [k isa Symbol ? k : Symbol(k) for k in ks]
-      allunique(inferred_syms) || return nothing
-      return inferred_syms
-    end
-  end
-
   return nothing
 end
 
@@ -333,9 +323,7 @@ function _materialize_labels(labels, n::Int)
   return collect(labels)
 end
 
-parameter_syms(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
-profile_syms(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
-profile_labels(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
+labels(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
 
 function _materialize_profile_bound(b, I::Int)
   if b isa Real

--- a/src/problem_interface.jl
+++ b/src/problem_interface.jl
@@ -212,10 +212,10 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
 end
 
 function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::AbstractVector{<:Real}; 
-  idxs=nothing, profile_lower=nothing, profile_upper=nothing, labels=nothing, kwargs...)
+  idxs=nothing, profile_lower=nothing, profile_upper=nothing, kwargs...)
   
   n = length(optpars)
-  param_labels = _materialize_parameter_labels(labels, optpars)
+  param_labels = _infer_container_labels(optpars)
   lb = isnothing(profile_lower) ? optprob.lb : profile_lower
   ub = isnothing(profile_upper) ? optprob.ub : profile_upper
   (isnothing(lb) || isnothing(ub)) &&
@@ -235,7 +235,7 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
 end
 
 function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::AbstractVector{<:Real}, fs::Union{F, AbstractVector{F}}; 
-  profile_lower=nothing, profile_upper=nothing, labels=nothing, kwargs...) where {F<:OptimizationFunction}
+  profile_lower=nothing, profile_upper=nothing, kwargs...) where {F<:OptimizationFunction}
 
   (isnothing(profile_lower) || isnothing(profile_upper)) &&
     throw(ArgumentError("Function targets require `profile_lower` and `profile_upper` (scalar or vector)."))
@@ -245,7 +245,8 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
   ubv = _materialize_profile_bound(profile_upper, length(Fs))
   lbv_typed, ubv_typed = _ensure_real_bounds(lbv, ubv)
 
-  prof_labels = isnothing(labels) ? Symbol.("f", 1:length(Fs)) : labels
+  inferred_labels = _infer_container_labels(fs)
+  prof_labels = isnothing(inferred_labels) ? Symbol.("f", 1:length(Fs)) : inferred_labels
   tgt = FunctionTarget(; fs=Fs, profile_lower=lbv_typed, profile_upper=ubv_typed, labels=prof_labels)
   return ProfileLikelihoodProblem(optprob, optpars, tgt; kwargs...)
 end
@@ -298,20 +299,15 @@ function _symbol_to_idx(s::Symbol, labels, n::Int)
   return idx
 end
 
-function _infer_parameter_labels(optpars::AbstractVector)
+function _infer_container_labels(x)
   return nothing
 end
 
-function _materialize_parameter_labels(labels, optpars::AbstractVector)
-  if isnothing(labels)
-    return _infer_parameter_labels(optpars)
-  end
-  labels isa AbstractVector{<:Symbol} || throw(ArgumentError("`labels` must be a vector of Symbols."))
-  length(labels) == length(optpars) ||
-    throw(DimensionMismatch("For parameter profiling, when provided, `labels` must have `length(optpars)` entries."))
-  allunique(labels) || throw(ArgumentError("`labels` must contain unique symbols."))
-  return collect(labels)
+function _infer_container_labels(x::AbstractVector)
+  return _infer_container_labels(typeof(x), x)
 end
+
+_infer_container_labels(::Type, x) = nothing
 
 function _materialize_labels(labels, n::Int)
   if isnothing(labels)
@@ -323,7 +319,7 @@ function _materialize_labels(labels, n::Int)
   return collect(labels)
 end
 
-labels(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
+profile_labels(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
 
 function _materialize_profile_bound(b, I::Int)
   if b isa Real

--- a/src/problem_interface.jl
+++ b/src/problem_interface.jl
@@ -19,21 +19,24 @@ Create a target with explicit lower and upper bounds for each index.
 ParameterTarget(; idxs::AbstractVector{<:Integer}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real})
 ```
 """
-struct ParameterTarget{I<:AbstractVector{<:Integer}, B<:AbstractVector{<:Real}} <: AbstractProfileTarget
+struct ParameterTarget{I<:AbstractVector{<:Integer}, B<:AbstractVector{<:Real}, L} <: AbstractProfileTarget
   idxs::I
   profile_lower::B
   profile_upper::B
+  labels::L
 
   function ParameterTarget(idxs::I, 
                            profile_lower::AbstractVector{<:Real}, 
-                           profile_upper::AbstractVector{<:Real}) where {I<:AbstractVector{<:Integer}}
+                           profile_upper::AbstractVector{<:Real},
+                           labels = nothing) where {I<:AbstractVector{<:Integer}}
     n = length(idxs)
     n > 0           || throw(ArgumentError("`idxs` must be non-empty."))
     allunique(idxs) || throw(ArgumentError("`idxs` must be unique."))
     all(>=(1), idxs) || throw(ArgumentError("`idxs` must be positive integers."))
+    labels_typed = _materialize_labels(labels, n)
     
     lb_typed, ub_typed = _promote_profile_bounds(profile_lower, profile_upper, n)
-    new{I,typeof(lb_typed)}(idxs, lb_typed, ub_typed)
+    new{I,typeof(lb_typed),typeof(labels_typed)}(idxs, lb_typed, ub_typed, labels_typed)
   end
 end
 
@@ -61,18 +64,21 @@ Create a target with explicit lower and upper bounds for each function of parame
 FunctionTarget(; fs::AbstractVector{<:OptimizationFunction}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real})
 ```
 """
-struct FunctionTarget{F<:AbstractVector{<:OptimizationFunction}, B<:AbstractVector{<:Real}} <: AbstractProfileTarget
+struct FunctionTarget{F<:AbstractVector{<:OptimizationFunction}, B<:AbstractVector{<:Real}, L} <: AbstractProfileTarget
   fs::F
   profile_lower::B
   profile_upper::B
+  labels::L
 
   function FunctionTarget(fs::F, 
                            profile_lower::AbstractVector{<:Real}, 
-                           profile_upper::AbstractVector{<:Real}) where {F<:AbstractVector{<:OptimizationFunction}}
+                           profile_upper::AbstractVector{<:Real},
+                           labels = nothing) where {F<:AbstractVector{<:OptimizationFunction}}
     n = length(fs)
     n > 0 || throw(ArgumentError("`fs` must be non-empty."))
+    labels_typed = _materialize_labels(labels, n)
     lb_typed, ub_typed = _promote_profile_bounds(profile_lower, profile_upper, n)
-    new{F,typeof(lb_typed)}(fs, lb_typed, ub_typed)
+    new{F,typeof(lb_typed),typeof(labels_typed)}(fs, lb_typed, ub_typed, labels_typed)
   end
 end
 
@@ -101,14 +107,15 @@ function get_idx_profile_ub(t::AbstractProfileTarget, idx)
 end
 
 get_profile_fs(ft::FunctionTarget) = ft.fs
+get_profile_labels(t::AbstractProfileTarget) = t.labels
 
 ############################### CONSTRUCTORS ###############################
 
-ParameterTarget(; idxs::AbstractVector{<:Integer}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real}) =
-  ParameterTarget(idxs, profile_lower, profile_upper)
+ParameterTarget(; idxs::AbstractVector{<:Integer}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real}, labels=nothing) =
+  ParameterTarget(idxs, profile_lower, profile_upper, labels)
 
-FunctionTarget(; fs::AbstractVector{<:OptimizationFunction}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real}) =
-  FunctionTarget(fs, profile_lower, profile_upper)
+FunctionTarget(; fs::AbstractVector{<:OptimizationFunction}, profile_lower::AbstractVector{<:Real}, profile_upper::AbstractVector{<:Real}, labels=nothing) =
+  FunctionTarget(fs, profile_lower, profile_upper, labels)
 
 ################################ HELPERS ################################
 
@@ -177,6 +184,9 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", plprob::ProfileLikelihoodProblem) 
   println(io, "Profile Likelihood Problem. Profile threshold: $(plprob.threshold)")
   show(io, mime, plprob.target)
+  if !isnothing(get_profile_labels(plprob.target))
+    println(io, "Profile labels: $(get_profile_labels(plprob.target))")
+  end
   println(io, "Parameters' optimal values: ")
   show(io, mime, plprob.optpars)
 end
@@ -202,15 +212,16 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
 end
 
 function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::AbstractVector{<:Real}; 
-  idxs=nothing, profile_lower=nothing, profile_upper=nothing, kwargs...)
+  idxs=nothing, profile_lower=nothing, profile_upper=nothing, labels=nothing, kwargs...)
   
   n = length(optpars)
+  param_labels = _materialize_parameter_labels(labels, optpars)
   lb = isnothing(profile_lower) ? optprob.lb : profile_lower
   ub = isnothing(profile_upper) ? optprob.ub : profile_upper
   (isnothing(lb) || isnothing(ub)) &&
      throw(ArgumentError("Bounds not found in `OptimizationProblem`; pass `profile_lower`/`profile_upper`."))
 
-  I = _materialize_idxs(idxs, n)
+  I = _materialize_idxs(idxs, n; syms=param_labels)
   lbv = _materialize_profile_bound(lb, length(I))
   ubv = _materialize_profile_bound(ub, length(I))
 
@@ -218,12 +229,13 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
   ubI = (length(ubv) == n) ? ubv[I] : ubv
   lbv_typed, ubv_typed = _ensure_real_bounds(lbI, ubI)
   
-  tgt = ParameterTarget(; idxs=I, profile_lower=lbv_typed, profile_upper=ubv_typed)
+  prof_labels = isnothing(param_labels) ? nothing : param_labels[I]
+  tgt = ParameterTarget(; idxs=I, profile_lower=lbv_typed, profile_upper=ubv_typed, labels=prof_labels)
   return ProfileLikelihoodProblem(optprob, optpars, tgt; kwargs...)
 end
 
 function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::AbstractVector{<:Real}, fs::Union{F, AbstractVector{F}}; 
-  profile_lower=nothing, profile_upper=nothing, kwargs...) where {F<:OptimizationFunction}
+  profile_lower=nothing, profile_upper=nothing, labels=nothing, kwargs...) where {F<:OptimizationFunction}
 
   (isnothing(profile_lower) || isnothing(profile_upper)) &&
     throw(ArgumentError("Function targets require `profile_lower` and `profile_upper` (scalar or vector)."))
@@ -233,7 +245,8 @@ function ProfileLikelihoodProblem(optprob::OptimizationProblem, optpars::Abstrac
   ubv = _materialize_profile_bound(profile_upper, length(Fs))
   lbv_typed, ubv_typed = _ensure_real_bounds(lbv, ubv)
 
-  tgt = FunctionTarget(; fs=Fs, profile_lower=lbv_typed, profile_upper=ubv_typed)
+  prof_labels = isnothing(labels) ? Symbol.("f", 1:length(Fs)) : labels
+  tgt = FunctionTarget(; fs=Fs, profile_lower=lbv_typed, profile_upper=ubv_typed, labels=prof_labels)
   return ProfileLikelihoodProblem(optprob, optpars, tgt; kwargs...)
 end
 
@@ -257,17 +270,72 @@ function _check_prob_target(optprob::OptimizationProblem, optpars::AbstractVecto
   return nothing
 end
 
-function _materialize_idxs(idxs, n::Int)
+function _materialize_idxs(idxs, n::Int; syms=nothing)
   if isnothing(idxs)
     return collect(Base.OneTo(n))
   elseif idxs isa Integer && 1 <= idxs <= n
     return [Int(idxs)]
   elseif idxs isa AbstractVector{<:Integer} && all(1 .<= idxs .<= n)
     return Int.(collect(idxs))
+  elseif idxs isa Symbol
+    return [_symbol_to_idx(idxs, syms, n)]
+  elseif idxs isa AbstractVector{<:Symbol}
+    return [_symbol_to_idx(s, syms, n) for s in idxs]
+  elseif idxs isa AbstractVector && all(x -> (x isa Integer || x isa Symbol), idxs)
+    I = [x isa Integer ? Int(x) : _symbol_to_idx(x, syms, n) for x in idxs]
+    all(1 .<= I .<= n) || throw(ArgumentError("`idxs` must be within 1:$n."))
+    return I
   else
-    throw(ArgumentError("`idxs` must be a positive Integer or a vector of positive Integers."))
+    throw(ArgumentError("`idxs` must be an Integer, Symbol, or a vector of Integers/Symbols."))
   end
 end
+
+function _symbol_to_idx(s::Symbol, syms, n::Int)
+  isnothing(syms) &&
+    throw(ArgumentError("Symbolic `idxs` requested but parameter symbols were not detected. Pass named `ComponentArray` as `optpars` (e.g. `ComponentArray(a=..., b=...)`) or use integer indices."))
+  idx = findfirst(==(s), syms)
+  isnothing(idx) && throw(ArgumentError("Symbol `$s` is not present in parameter symbols $syms."))
+  return idx
+end
+
+function _infer_parameter_labels(optpars::AbstractVector)
+  n = length(optpars)
+  if optpars isa ComponentArrays.ComponentArray
+    ks = collect(keys(optpars))
+    if length(ks) == n && all(k -> (k isa Symbol || k isa AbstractString), ks)
+      inferred_syms = [k isa Symbol ? k : Symbol(k) for k in ks]
+      allunique(inferred_syms) || return nothing
+      return inferred_syms
+    end
+  end
+
+  return nothing
+end
+
+function _materialize_parameter_labels(labels, optpars::AbstractVector)
+  if isnothing(labels)
+    return _infer_parameter_labels(optpars)
+  end
+  labels isa AbstractVector{<:Symbol} || throw(ArgumentError("`labels` must be a vector of Symbols."))
+  length(labels) == length(optpars) ||
+    throw(DimensionMismatch("For parameter profiling, when provided, `labels` must have `length(optpars)` entries."))
+  allunique(labels) || throw(ArgumentError("`labels` must contain unique symbols."))
+  return collect(labels)
+end
+
+function _materialize_labels(labels, n::Int)
+  if isnothing(labels)
+    return nothing
+  end
+  labels isa AbstractVector{<:Symbol} || throw(ArgumentError("`labels` must be a vector of Symbols."))
+  length(labels) == n || throw(DimensionMismatch("`labels` must have length $n."))
+  allunique(labels) || throw(ArgumentError("`labels` must contain unique symbols."))
+  return collect(labels)
+end
+
+parameter_syms(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
+profile_syms(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
+profile_labels(plprob::ProfileLikelihoodProblem) = get_profile_labels(plprob.target)
 
 function _materialize_profile_bound(b, I::Int)
   if b isa Real
@@ -302,6 +370,5 @@ function SciMLBase.remake(plprob::ProfileLikelihoodProblem;
   if threshold === missing
     threshold = plprob.threshold
   end
-
   return ProfileLikelihoodProblem(optprob, optpars, target; threshold)
 end

--- a/src/profile_solution.jl
+++ b/src/profile_solution.jl
@@ -201,7 +201,7 @@ end
 
 Base.getindex(A::ProfileLikelihoodSolution, i::Int) = A.profiles[i]
 function Base.getindex(A::ProfileLikelihoodSolution, i::Symbol)
-  lbls = labels(A.prob)
+  lbls = profile_labels(A.prob)
   isnothing(lbls) && throw(ArgumentError("No symbolic labels are defined for this solution."))
   idx = findfirst(==(i), lbls)
   isnothing(idx) && throw(BoundsError("Symbol `$i` is not among profiled labels $lbls"))
@@ -210,7 +210,7 @@ end
 Base.size(A::ProfileLikelihoodSolution) = size(A.profiles)
 Base.length(A::ProfileLikelihoodSolution) = length(A.profiles)
 
-labels(sol::ProfileLikelihoodSolution) = labels(sol.prob)
+profile_labels(sol::ProfileLikelihoodSolution) = profile_labels(sol.prob)
 
 endpoints(sol::ProfileLikelihoodSolution) = endpoints.(sol.profiles)
 retcodes(sol::ProfileLikelihoodSolution) = retcodes.(sol.profiles)

--- a/src/profile_solution.jl
+++ b/src/profile_solution.jl
@@ -201,14 +201,16 @@ end
 
 Base.getindex(A::ProfileLikelihoodSolution, i::Int) = A.profiles[i]
 function Base.getindex(A::ProfileLikelihoodSolution, i::Symbol)
-  syms = profile_syms(A.prob)
-  isnothing(syms) && throw(ArgumentError("No symbolic parameter mapping is defined for this solution."))
-  idx = findfirst(==(i), syms)
-  isnothing(idx) && throw(BoundsError("Symbol `$i` is not among profiled symbols $syms"))
+  lbls = labels(A.prob)
+  isnothing(lbls) && throw(ArgumentError("No symbolic labels are defined for this solution."))
+  idx = findfirst(==(i), lbls)
+  isnothing(idx) && throw(BoundsError("Symbol `$i` is not among profiled labels $lbls"))
   return A.profiles[idx]
 end
 Base.size(A::ProfileLikelihoodSolution) = size(A.profiles)
 Base.length(A::ProfileLikelihoodSolution) = length(A.profiles)
+
+labels(sol::ProfileLikelihoodSolution) = labels(sol.prob)
 
 endpoints(sol::ProfileLikelihoodSolution) = endpoints.(sol.profiles)
 retcodes(sol::ProfileLikelihoodSolution) = retcodes.(sol.profiles)

--- a/src/profile_solution.jl
+++ b/src/profile_solution.jl
@@ -200,6 +200,13 @@ function Base.show(io::IO, mime::MIME"text/plain", pc::ProfileLikelihoodSolution
 end
 
 Base.getindex(A::ProfileLikelihoodSolution, i::Int) = A.profiles[i]
+function Base.getindex(A::ProfileLikelihoodSolution, i::Symbol)
+  syms = profile_syms(A.prob)
+  isnothing(syms) && throw(ArgumentError("No symbolic parameter mapping is defined for this solution."))
+  idx = findfirst(==(i), syms)
+  isnothing(idx) && throw(BoundsError("Symbol `$i` is not among profiled symbols $syms"))
+  return A.profiles[idx]
+end
 Base.size(A::ProfileLikelihoodSolution) = size(A.profiles)
 Base.length(A::ProfileLikelihoodSolution) = length(A.profiles)
 

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -1,5 +1,6 @@
 using Test
 using LikelihoodProfiler
+using ComponentArrays
 
 # ----------------------------
 # ParameterTarget constructors
@@ -121,6 +122,44 @@ end
         idxs=0, profile_lower=-1.0, profile_upper=1.0)
     @test_throws ArgumentError ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0];
         idxs=[1,4], profile_lower=-1.0, profile_upper=1.0)
+end
+
+@testset "PL sugar: symbolic parameter indexing" begin
+    f = OptimizationFunction((x,p)->x[1]^2 + x[2]^2 + x[3]^2)
+    optpars = ComponentArray(a=0.0, b=0.0, c=0.0)
+    optprob = OptimizationProblem(f, [1.0, 2.0, 3.0])
+
+    prob = ProfileLikelihoodProblem(optprob, optpars;
+        idxs=[:a, :c], profile_lower=-5.0, profile_upper=5.0)
+    @test prob.target.idxs == [1, 3]
+    @test parameter_syms(prob) == [:a, :c]
+    @test profile_syms(prob) == [:a, :c]
+
+    # mixing integer and symbolic indexing is supported
+    prob_mixed = ProfileLikelihoodProblem(optprob, optpars;
+        idxs=Any[1, :c], profile_lower=-5.0, profile_upper=5.0)
+    @test prob_mixed.target.idxs == [1, 3]
+
+    # symbolic idxs are not available without named parameters
+    @test_throws ArgumentError ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0];
+        idxs=[:a], profile_lower=-1.0, profile_upper=1.0)
+    @test_throws ArgumentError ProfileLikelihoodProblem(optprob, optpars;
+        idxs=[:z], profile_lower=-1.0, profile_upper=1.0)
+end
+
+@testset "Function target labels" begin
+    f = OptimizationFunction((x,p)->sum(abs2, x))
+    optprob = OptimizationProblem(f, [1.0, 2.0, 3.0])
+    g1 = OptimizationFunction((x,p)->x[1] + x[2])
+    g2 = OptimizationFunction((x,p)->x[2] - x[3])
+
+    prob_default = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
+        profile_lower=-2.0, profile_upper=2.0)
+    @test profile_syms(prob_default) == [:f1, :f2]
+
+    prob_named = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
+        profile_lower=-2.0, profile_upper=2.0, labels=[:sum12, :diff23])
+    @test profile_syms(prob_named) == [:sum12, :diff23]
 end
 
 # ----------------------------

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -132,7 +132,7 @@ end
     prob = ProfileLikelihoodProblem(optprob, optpars;
         idxs=[:a, :c], profile_lower=-5.0, profile_upper=5.0)
     @test prob.target.idxs == [1, 3]
-    @test labels(prob) == [:a, :c]
+    @test profile_labels(prob) == [:a, :c]
 
     # mixing integer and symbolic indexing is supported
     prob_mixed = ProfileLikelihoodProblem(optprob, optpars;
@@ -154,15 +154,12 @@ end
 
     prob_default = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
         profile_lower=-2.0, profile_upper=2.0)
-    @test labels(prob_default) == [:f1, :f2]
+    @test profile_labels(prob_default) == [:f1, :f2]
 
-    prob_named = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
-        profile_lower=-2.0, profile_upper=2.0, labels=[:sum12, :diff23])
-    @test labels(prob_named) == [:sum12, :diff23]
-    @test_throws DimensionMismatch ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
-        profile_lower=-2.0, profile_upper=2.0, labels=[:only_one])
-    @test_throws ArgumentError ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
-        profile_lower=-2.0, profile_upper=2.0, labels=[:dup, :dup])
+    fs_named = ComponentArray(sum12=g1, diff23=g2)
+    prob_named = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], fs_named;
+        profile_lower=-2.0, profile_upper=2.0)
+    @test profile_labels(prob_named) == [:sum12, :diff23]
 end
 
 # ----------------------------

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -132,8 +132,7 @@ end
     prob = ProfileLikelihoodProblem(optprob, optpars;
         idxs=[:a, :c], profile_lower=-5.0, profile_upper=5.0)
     @test prob.target.idxs == [1, 3]
-    @test parameter_syms(prob) == [:a, :c]
-    @test profile_syms(prob) == [:a, :c]
+    @test labels(prob) == [:a, :c]
 
     # mixing integer and symbolic indexing is supported
     prob_mixed = ProfileLikelihoodProblem(optprob, optpars;
@@ -155,11 +154,15 @@ end
 
     prob_default = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
         profile_lower=-2.0, profile_upper=2.0)
-    @test profile_syms(prob_default) == [:f1, :f2]
+    @test labels(prob_default) == [:f1, :f2]
 
     prob_named = ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
         profile_lower=-2.0, profile_upper=2.0, labels=[:sum12, :diff23])
-    @test profile_syms(prob_named) == [:sum12, :diff23]
+    @test labels(prob_named) == [:sum12, :diff23]
+    @test_throws DimensionMismatch ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
+        profile_lower=-2.0, profile_upper=2.0, labels=[:only_one])
+    @test_throws ArgumentError ProfileLikelihoodProblem(optprob, [0.0, 0.0, 0.0], [g1, g2];
+        profile_lower=-2.0, profile_upper=2.0, labels=[:dup, :dup])
 end
 
 # ----------------------------


### PR DESCRIPTION
### Motivation

- Allow users to attach symbolic labels to profiled parameters and functions and index profiles by those symbols instead of only integer indices.
- Make plotting and solution access use human-readable labels when available for clearer output and interaction.
- Ensure constrained `OptimizationFunction` construction forwards all relevant properties to avoid losing metadata.

### Description

- Added `labels` fields to `ParameterTarget` and `FunctionTarget`, added `labels` keyword to their constructors, and exposed `get_profile_labels` as `parameter_syms`, `profile_syms`, and `profile_labels` via the module export list.
- Implemented symbolic indexing support by extending `_materialize_idxs` to accept `Symbol`(s) and by adding `_symbol_to_idx`, `_infer_parameter_labels`, `_materialize_parameter_labels`, and `_materialize_labels` helpers which infer symbols from a `ComponentArray` `optpars` or validate user-provided `labels`.
- Updated `ProfileLikelihoodProblem` constructors to accept `labels` and to propagate inferred/selected labels into the created `ParameterTarget`/`FunctionTarget`; updated `Base.show` to print labels when present.
- Improved plotting recipe to use `profile_syms` for x-axis labels and added `Base.getindex(::ProfileLikelihoodSolution, ::Symbol)` to access profiles by symbol.
- Fixed `build_optf_constrained` to forward all non-special properties from the original `optprob.f` into the returned `OptimizationFunction` via a `kwargs` `Dict` to preserve metadata (`grad`, `hess`, etc.).
- Updated tests to cover symbolic parameter indexing and function target labels and added `using ComponentArrays` in the tests.

### Testing

- Ran the package interface tests in `test/test_interface.jl`, including new testsets `"PL sugar: symbolic parameter indexing"` and `"Function target labels"`, and they succeeded.
- Existing parameter- and function-target constructor tests in `test/test_interface.jl` were run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e368856418832bb2c8053e20e20b32)