### PR TITLE
Refactor solve flow via internal __solve dispatcher

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -57,12 +57,28 @@ function SciMLBase.solve(plprob::ProfileLikelihoodProblem, method::AbstractProfi
   verbose && @info "Computing initial values."
   obj0 = evaluate_obj(_plprob, _plprob.optpars)
 
+  return __solve(_plprob, method; obj0, parallel_type, verbose, kwargs...)
+end
+
+"""
+    __solve(plprob::ProfileLikelihoodProblem, method::AbstractProfilerMethod; 
+            parallel_type::Symbol=:none, kwargs...)
+
+Internal solve dispatcher used by `solve` after input validation and optional re-optimization.
+By default, it constructs parameter profile branches `(idx, dir)` and forwards them to
+`__solve_parallel`. Profilers with a different execution model (e.g. non-branch methods)
+can overload this function.
+"""
+function __solve(plprob::ProfileLikelihoodProblem, method::AbstractProfilerMethod; 
+  parallel_type::Symbol=:none, kwargs...)
+
   !(parallel_type in (:none, :threads, :distributed)) && 
     throw(ArgumentError("Invalid `parallel_type`: $parallel_type. 
                          Supported values are :none, :threads, :distributed."))
+
   II = [(idx, dir) for idx in get_profile_idxs(plprob.target) for dir in (-1, 1)]
 
-  return __solve_parallel(_plprob, method, Val(parallel_type), II; obj0, verbose, kwargs...)
+  return __solve_parallel(plprob, method, Val(parallel_type), II; kwargs...)
 end
 
 ###################################### PARALLEL SOLVE ##################################


### PR DESCRIPTION
### Motivation

- Create a clean extension point in the profiling execution flow so non-branch profilers (e.g. a Fisher Information Matrix based `FIMProfiler`) can implement a different execution model without changing the public `solve` API.

### Description

- Extracted branch-construction and parallel dispatch logic from `SciMLBase.solve` into a new internal `__solve` dispatcher that runs after input validation and optional re-optimization.
- Implemented a default `__solve(plprob::ProfileLikelihoodProblem, method::AbstractProfilerMethod; parallel_type::Symbol=:none, kwargs...)` that validates `parallel_type`, builds `II = [(idx, dir) for idx in get_profile_idxs(plprob.target) for dir in (-1,1)]`, and forwards to `__solve_parallel` to preserve existing behavior.
- Updated `SciMLBase.solve` to perform checks, optional re-optimization, and initial objective evaluation, and then call the new `__solve` dispatcher using the same public signature.
- This refactor provides a straightforward place to add a specialized `__solve(plprob, method::FIMProfiler; ...)` that can skip branch construction and adjust or ignore `parallel_type` as needed.

### Testing

- Attempted to run unit tests with `julia --project -e 'using Pkg; Pkg.test(;test_args=["test_interface.jl"])'`, but the execution failed due to the environment lacking `julia` (`julia: command not found`).
- No automated tests were executed successfully in this environment; existing parallel tests in `test/test_parallel.jl` remain unchanged and should continue to pass when run in a proper Julia environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f07ec0c3e8832bba04fd2adc52273d)