### PR TITLE
Add `xtransform` plotting option to ProfileLikelihood recipes

### DIFF
--- a/docs/src/solution_interface.md
+++ b/docs/src/solution_interface.md
@@ -26,6 +26,7 @@ The following keyword arguments can be used in `plot` function:
 
 - `steps::Bool` - whether to scatter steps performed by the profiler. Defaults to `true`.
 - `threshold::Bool` - whether to plot `threshold` defined in `ProfileLikelihoodProblem`. Defaults to `isfinite(threshold)`
+- `xtransform::Function` - transform applied to x-values before plotting (e.g. `exp10` to show log10-parameter profiles in linear space). Defaults to `identity`.
 
 Also each profile contained in the `sol::ProfileLikelihoodSolution` can be represented as a DataFrame with `DataFrame(sol[i])`.
 If profile labels are present, symbolic indexing is available: `sol[:label]`.

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,5 +1,5 @@
 
-@recipe function f(sol::ProfileLikelihoodSolution)
+@recipe function f(sol::ProfileLikelihoodSolution; xtransform=identity)
   ls = length(sol)
   lbls = profile_labels(sol)
 
@@ -10,25 +10,26 @@
       subplot := i
       xguide --> xlbl
       yguide --> "objective function"
+      xtransform := xtransform
       sol[i]
     end
   end
   return nothing
 end
 
-@recipe function f(c::ProfileCurve; steps=true, threshold=hasthreshold(c.plprob), endpoints=false)
+@recipe function f(c::ProfileCurve; steps=true, threshold=hasthreshold(c.plprob), endpoints=false, xtransform=identity)
 
   @series begin
     color --> :blue
     linewidth --> 3
     endpoints ? (label --> "CI interval") : (label --> "profile")
-    (c.x, c.obj)
+    (xtransform.(c.x), c.obj)
   end
   if steps 
     @series begin
       seriestype --> :scatter
       endpoints ? (label --> "CI endpoints") : (label --> "profiler steps")
-      (c.x, c.obj)
+      (xtransform.(c.x), c.obj)
     end
   end 
   if threshold


### PR DESCRIPTION
### Motivation
- Provide a way to transform x-axis values when plotting profile likelihoods (for example, to plot log10-parameter profiles in linear space).

### Description
- Add a `xtransform=identity` keyword argument to the plotting recipes in `src/plotting.jl` and apply `xtransform.(c.x)` to both the profile and step series; update `docs/src/solution_interface.md` to document the new `xtransform::Function` plotting keyword.

### Testing
- Ran the package test suite with `] test` and verified the plotting recipes load and execute; automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcf9183ddc832b978c4b7374597e99)